### PR TITLE
chrony-4.0-3.amzn2.0.2 -> chrony-4.2-5.amzn2.0.1 moves the pool to a …

### DIFF
--- a/tasks/level-1/2.1.1.3.yml
+++ b/tasks/level-1/2.1.1.3.yml
@@ -5,7 +5,7 @@
 
 - name: 2.1.1.3 verify a remote chrony server is configured
   command: >
-    egrep -c '^(server|pool)' /etc/chrony.conf
+    egrep -c '^(server|pool)' /etc/chrony.d/ntp-pool.conf
   register: line_matched
   when: cis_enable_chrony and not cis_enable_ntp
   tags:


### PR DESCRIPTION
….d conf fragment